### PR TITLE
Implement store-level id mapping

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -2,6 +2,8 @@ name: Typecheck
 
 on:
   push:
+    branches:
+    - main
   pull_request:
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode
 *.mixxxlib
 *.musiclib
+*.zip
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/mixync/__init__.py
+++ b/mixync/__init__.py
@@ -30,6 +30,7 @@ def main():
     parser.add_argument('dest', help='The destination ref (to be copied to)')
     parser.add_argument('-d', '--dest-root-dir', type=str, help='A root folder to place copied music directories in. Only used by some destination stores.')
     parser.add_argument('-y', '--assume-yes', action='store_true', help='Whether to disable interactive prompts.')
+    parser.add_argument('-v', '--verbose', action='store_true', help='Whether to log verbosely.')
     parser.add_argument('--dry-run', action='store_true', help='Whether to skip all actual file changes.')
 
     args = parser.parse_args()
@@ -42,6 +43,7 @@ def main():
     dest = parse_ref(args.dest)
     opts = Options(
         log=True,
+        verbose=args.verbose,
         dry_run=args.dry_run,
         assume_yes=args.assume_yes,
         dest_root_dir=Path(args.dest_root_dir) if args.dest_root_dir else None

--- a/mixync/model/crate.py
+++ b/mixync/model/crate.py
@@ -1,16 +1,17 @@
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Optional
 
 @dataclass
 class CrateHeader:
-    id: int
+    id: Optional[int]
     name: str
 
 @dataclass
 class Crate:
     """An unordered list of tracks."""
 
-    id: int
+    id: Optional[int]
     name: str = ''
     date_created: datetime = field(default_factory=datetime.now)
     date_modified: datetime = field(default_factory=datetime.now)

--- a/mixync/model/crate.py
+++ b/mixync/model/crate.py
@@ -17,7 +17,7 @@ class Crate:
     date_modified: datetime = field(default_factory=datetime.now)
     hidden: bool = False
     locked: bool = False
-    track_ids: set[str] = field(default_factory=lambda: set())
+    track_ids: set[int] = field(default_factory=lambda: set())
 
     def header(self) -> CrateHeader:
         return CrateHeader(

--- a/mixync/model/directory.py
+++ b/mixync/model/directory.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
+from typing import Optional
 
 @dataclass
 class Directory:
     """A music directory containing audio files."""
 
+    id: Optional[int]
     location: str
-

--- a/mixync/model/directory.py
+++ b/mixync/model/directory.py
@@ -5,5 +5,5 @@ from typing import Optional
 class Directory:
     """A music directory containing audio files."""
 
-    id: Optional[int]
+    id: int
     location: str

--- a/mixync/model/directory.py
+++ b/mixync/model/directory.py
@@ -5,5 +5,5 @@ from typing import Optional
 class Directory:
     """A music directory containing audio files."""
 
-    id: int
+    id: Optional[int]
     location: str

--- a/mixync/model/playlist.py
+++ b/mixync/model/playlist.py
@@ -20,7 +20,7 @@ class Playlist:
     date_modified: datetime = field(default_factory=datetime.now)
     type: PlaylistType = PlaylistType.DEFAULT
     locked: bool = False
-    track_ids: list[str] = field(default_factory=lambda: [])
+    track_ids: list[int] = field(default_factory=lambda: [])
 
     def header(self) -> PlaylistHeader:
         return PlaylistHeader(

--- a/mixync/model/playlist.py
+++ b/mixync/model/playlist.py
@@ -1,20 +1,19 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Optional
-from uuid import uuid4
 
 from mixync.model.playlist_type import PlaylistType
 
 @dataclass
 class PlaylistHeader:
-    id: int
+    id: Optional[int]
     name: str
 
 @dataclass
 class Playlist:
     """An ordered list of tracks."""
 
-    id: int
+    id: Optional[int]
     name: str = ''
     position: Optional[int] = None
     date_created: datetime = field(default_factory=datetime.now)

--- a/mixync/model/track.py
+++ b/mixync/model/track.py
@@ -8,7 +8,7 @@ from mixync.model.keys import Keys
 
 @dataclass
 class TrackHeader:
-    id: int
+    id: Optional[int]
     name: str
     artist: str
 
@@ -16,7 +16,7 @@ class TrackHeader:
 class Track:
     """A song."""
 
-    id: int
+    id: Optional[int]
     name: str = ''
     artist: str = ''
     location: str = ''

--- a/mixync/options.py
+++ b/mixync/options.py
@@ -8,6 +8,8 @@ class Options:
     skip_uncategorized: bool = True
     # Whether to log output during the copy.
     log: bool = False
+    # Whether to log output verbosely during the copy.
+    verbose: bool = False
     # Whether to skip all actual file changes.
     dry_run: bool = False
     # Whether to disable interactive prompts.

--- a/mixync/store/__init__.py
+++ b/mixync/store/__init__.py
@@ -136,8 +136,18 @@ class Store:
     def copy_playlists_to(self, other: Store, id_mappings: IdMappings, opts: Options):
         """Copies playlists to the given store."""
         playlists = list(self.playlists())
-        # TODO: Map track ids
-        mapped_playlists = id_mappings.playlists.apply_or_match(playlists, lambda ps: self.match_playlists([p.header() for p in ps]))
+        # Map playlist ids and their track ids
+        mapped_playlists = []
+        for playlist in id_mappings.playlists.apply_or_match(playlists, lambda ps: self.match_playlists([p.header() for p in ps])):
+            mapped_ids = set()
+            for track_id in playlist.track_ids:
+                mapped_id = id_mappings.tracks.get(track_id)
+                if mapped_id:
+                    mapped_ids.add(mapped_id)
+                else:
+                    print(f"Warning: Track id {track_id} from playlist '{playlist.name}' could not be mapped.")
+            mapped_playlists.append(replace(playlist, track_ids=mapped_ids))
+        # Update the playlists
         if not opts.dry_run:
             new_ids = other.update_playlists(mapped_playlists)
             id_mappings.playlists.update(playlists, new_ids)
@@ -147,8 +157,18 @@ class Store:
     def copy_crates_to(self, other: Store, id_mappings: IdMappings, opts: Options):
         """Copies crates to the given store."""
         crates = list(self.crates())
-        # TODO: Map track ids
-        mapped_crates = id_mappings.crates.apply_or_match(crates, lambda cs: self.match_crates([c.header() for c in cs]))
+        # Map crate ids and their track ids
+        mapped_crates = []
+        for crate in id_mappings.crates.apply_or_match(crates, lambda cs: self.match_crates([c.header() for c in cs])):
+            mapped_ids = set()
+            for track_id in crate.track_ids:
+                mapped_id = id_mappings.tracks.get(track_id)
+                if mapped_id:
+                    mapped_ids.add(mapped_id)
+                else:
+                    print(f"Warning: Track id {track_id} from crate '{crate.name}' could not be mapped.")
+            mapped_crates.append(replace(crate, track_ids=mapped_ids))
+        # Update the crates
         if not opts.dry_run:
             new_ids = other.update_crates(mapped_crates)
             id_mappings.crates.update(crates, new_ids)

--- a/mixync/store/__init__.py
+++ b/mixync/store/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 from copy import deepcopy
-from dataclasses import replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from shutil import get_terminal_size
-from typing import Optional, Iterable
+from typing import Callable, Optional, Iterable, TypeVar
 
 from mixync.model.crate import Crate, CrateHeader
 from mixync.model.directory import Directory
@@ -13,6 +13,46 @@ from mixync.options import Options
 from mixync.utils.cli import info
 from mixync.utils.progress import ProgressLine
 from mixync.utils.str import truncate
+from mixync.utils.list import with_compact, zip_or
+from mixync.utils.typing import HasId
+
+T = TypeVar('T', bound='HasId')
+
+@dataclass
+class IdMapping:
+    """Maps ids between stores for a specific resource (tracks/directories/...)."""
+
+    mapping: dict[int, int] = field(default_factory=dict)
+
+    def filter_unmapped(self, values: list[T]) -> list[Optional[T]]:
+        """Turns the values without a mapped id into None."""
+        return [None if v.id in self.mapping else v for v in values]
+    
+    def apply_or_match(self, values: list[T], matcher: Callable[[list[T]], list[Optional[int]]]) -> list[T]:
+        """Maps the values with a mapped id directly and uses the matcher function for all others."""
+        known_ids = [self.get(d.id) if d.id else None for d in values]
+        unmapped_values = self.filter_unmapped(values)
+        mapped_ids = zip_or(known_ids, with_compact(matcher, unmapped_values))
+        mapped_values = [replace(d, id=id) for d, id in zip(values, mapped_ids)]
+        return mapped_values
+    
+    def get(self, id: int) -> Optional[int]:
+        """Fetches the mapped value or none."""
+        return self.mapping.get(id, None)
+
+    def update(self, source: list[T], dest: list[T]):
+        for s, d in zip(source, dest):
+            if s.id and d.id:
+                self.mapping[s.id] = d.id
+
+@dataclass
+class IdMappings:
+    """Id mappings for the different resource types that stores deal with."""
+
+    tracks: IdMapping = field(default_factory=IdMapping)
+    directories: IdMapping = field(default_factory=IdMapping)
+    playlists: IdMapping = field(default_factory=IdMapping)
+    crates: IdMapping = field(default_factory=IdMapping)
 
 class Store:
     """A store interface for music and metadata, e.g. a local mixxxdb or a remote server."""
@@ -22,56 +62,59 @@ class Store:
 
         if opts.log:
             info(f'Copying from a {type(self).__name__} to a {type(other).__name__}')
+        
+        id_mappings = IdMappings()
 
         # TODO: Deltas?
         # TODO: Add methods for matching tracks to existing tracks in the DB
         #       at the store level? Perhaps just more fine grained query methods?
 
-        # Copy directory metadata
+        # Copy directory and track metadata
         # NOTE: It is important that directory metadata is copied first since
         #       the store implementation may e.g. prompt the user in
         #       'absolutize_directory' about the mapping before writing anything.
-        self.copy_directories_to(other, opts)
-
-        tracks, dest_tracks = self.copy_tracks_to(other, opts)
+        self.copy_directories_to(other, id_mappings, opts)
+        tracks, dest_tracks = self.copy_tracks_to(other, id_mappings, opts)
 
         # Copy actual track files
-        self.copy_track_files_to(other, opts, tracks, dest_tracks)
+        self.copy_track_files_to(other, tracks, dest_tracks, id_mappings, opts)
         
-        # Copy playlists
-        self.copy_playlists_to(other, opts)
-        
-        # Copy crates
-        self.copy_crates_to(other, opts)
+        # Copy playlists and crates
+        self.copy_playlists_to(other, id_mappings, opts)
+        self.copy_crates_to(other, id_mappings, opts)
 
-    def copy_directories_to(self, other: Store, opts: Options):
+    def copy_directories_to(self, other: Store, id_mappings: IdMappings, opts: Options):
         """Copies directory metadata to the given store."""
         directories = list(self.directories())
+        # Relativize paths here, absolute them in the other store
         rel_directories = [self.relativize_directory(d, opts) for d in directories]
         dest_directories = [other.absolutize_directory(d, opts) if d else None for d in rel_directories]
         updated_directories = [d for d in dest_directories if d]
-        directory_ids = self.match_directories(updated_directories)
-        mapped_directories = [replace(d, id=id) for d, id in zip(updated_directories, directory_ids)]
+        # Map the ids (by first looking up already known mappings, then matching)
+        mapped_directories = id_mappings.directories.apply_or_match(updated_directories, self.match_directories)
+        # Update the directories
         updated_directory_count = 0 if opts.dry_run else other.update_directories(mapped_directories)
         if opts.log:
             info(f'Copied {updated_directory_count} directory entries')
 
-    def copy_tracks_to(self, other: Store, opts: Options) -> tuple[list[Track], list[Optional[Track]]]:
+    def copy_tracks_to(self, other: Store, id_mappings: IdMappings, opts: Options) -> tuple[list[Track], list[Optional[Track]]]:
         """Copies track metadata ot the given store."""
         tracks = list(self.tracks())
+        # Relativize paths here, absolute them in the other store
         rel_tracks = [self.relativize_track(t, opts) for t in tracks]
         dest_tracks = [other.absolutize_track(t, opts) if t else None for t in rel_tracks]
         updated_tracks = [t for t in dest_tracks if t]
-        track_ids = self.match_tracks([t.header() for t in updated_tracks])
-        mapped_tracks = [replace(t, id=id) for t, id in zip(updated_tracks, track_ids)]
+        # Map the ids (by first looking up already known mappings, then matching)
+        mapped_tracks = id_mappings.tracks.apply_or_match(updated_tracks, lambda ts: self.match_tracks([t.header() for t in ts]))
+        # Update the tracks
         updated_track_count = 0 if opts.dry_run else other.update_tracks(mapped_tracks)
         if opts.log:
             info(f'Copied {updated_track_count} track entries')
         return tracks, dest_tracks
 
-    def copy_track_files_to(self, other: Store, opts: Options, tracks, dest_tracks):
+    def copy_track_files_to(self, other: Store, tracks: list[Track], dest_tracks: list[Optional[Track]], id_mappings: IdMappings, opts: Options):
         """Copies actual track files to the given store."""
-        zipped_tracks = [] if opts.dry_run else [(t, d) for t, d in zip(tracks, dest_tracks) if t and d]
+        zipped_tracks = [] if opts.dry_run else [(t, d) for t, d in zip(tracks, dest_tracks) if d]
         with ProgressLine(len(zipped_tracks), final_newline=opts.log) as progress:
             for track, dest_track in zipped_tracks:
                 location = track.location
@@ -87,22 +130,18 @@ class Store:
         if opts.log:
             info(f'Copied {len(zipped_tracks)} track files')
 
-    def copy_playlists_to(self, other: Store, opts: Options):
+    def copy_playlists_to(self, other: Store, id_mappings: IdMappings, opts: Options):
         """Copies playlists to the given store."""
         playlists = list(self.playlists())
-        playlist_ids = self.match_playlists([p.header() for p in playlists])
-        # TODO: Map track ids
-        mapped_playlists = [replace(p, id=id) for p, id in zip(playlists, playlist_ids)]
+        mapped_playlists = id_mappings.playlists.apply_or_match(playlists, lambda ps: self.match_playlists([p.header() for p in ps]))
         updated_playlist_count = 0 if opts.dry_run else other.update_playlists(mapped_playlists)
         if opts.log:
             info(f'Copied {updated_playlist_count} playlists')
     
-    def copy_crates_to(self, other: Store, opts: Options):
+    def copy_crates_to(self, other: Store, id_mappings: IdMappings, opts: Options):
         """Copies crates to the given store."""
         crates = list(self.crates())
-        crate_ids = self.match_crates([c.header() for c in crates])
-        # TODO: Map track ids
-        mapped_crates = [replace(c, id=id) for c, id in zip(crates, crate_ids)]
+        mapped_crates = id_mappings.crates.apply_or_match(crates, lambda cs: self.match_crates([c.header() for c in cs]))
         updated_crate_count = 0 if opts.dry_run else other.update_crates(mapped_crates)
         if opts.log:
             info(f'Copied {updated_crate_count} crates')

--- a/mixync/store/__init__.py
+++ b/mixync/store/__init__.py
@@ -14,9 +14,9 @@ from mixync.utils.cli import info
 from mixync.utils.progress import ProgressLine
 from mixync.utils.str import truncate
 from mixync.utils.list import with_compact, zip_or
-from mixync.utils.typing import HasId
+from mixync.utils.typing import Identifiable
 
-T = TypeVar('T', bound='HasId')
+T = TypeVar('T', bound='Identifiable')
 
 @dataclass
 class IdMapping:

--- a/mixync/store/__init__.py
+++ b/mixync/store/__init__.py
@@ -90,7 +90,7 @@ class Store:
         dest_directories = [other.absolutize_directory(d, opts) if d else None for d in rel_directories]
         updated_directories = [d for d in dest_directories if d]
         # Map the ids (by first looking up already known mappings, then matching)
-        mapped_directories = id_mappings.directories.apply_or_match(updated_directories, self.match_directories)
+        mapped_directories = id_mappings.directories.apply_or_match(updated_directories, other.match_directories)
         # Update the directories
         if not opts.dry_run:
             new_ids = other.update_directories(mapped_directories)
@@ -106,7 +106,7 @@ class Store:
         dest_tracks = [other.absolutize_track(t, opts) if t else None for t in rel_tracks]
         updated_tracks = [t for t in dest_tracks if t]
         # Map the ids (by first looking up already known mappings, then matching)
-        mapped_tracks = id_mappings.tracks.apply_or_match(updated_tracks, lambda ts: self.match_tracks([t.header() for t in ts]))
+        mapped_tracks = id_mappings.tracks.apply_or_match(updated_tracks, lambda ts: other.match_tracks([t.header() for t in ts]))
         # Update the tracks
         if not opts.dry_run:
             new_ids = other.update_tracks(mapped_tracks)
@@ -138,7 +138,7 @@ class Store:
         playlists = list(self.playlists())
         # Map playlist ids and their track ids
         mapped_playlists = []
-        for playlist in id_mappings.playlists.apply_or_match(playlists, lambda ps: self.match_playlists([p.header() for p in ps])):
+        for playlist in id_mappings.playlists.apply_or_match(playlists, lambda ps: other.match_playlists([p.header() for p in ps])):
             mapped_ids = set()
             for track_id in playlist.track_ids:
                 mapped_id = id_mappings.tracks.get(track_id)
@@ -159,7 +159,7 @@ class Store:
         crates = list(self.crates())
         # Map crate ids and their track ids
         mapped_crates = []
-        for crate in id_mappings.crates.apply_or_match(crates, lambda cs: self.match_crates([c.header() for c in cs])):
+        for crate in id_mappings.crates.apply_or_match(crates, lambda cs: other.match_crates([c.header() for c in cs])):
             mapped_ids = set()
             for track_id in crate.track_ids:
                 mapped_id = id_mappings.tracks.get(track_id)

--- a/mixync/store/__init__.py
+++ b/mixync/store/__init__.py
@@ -28,7 +28,7 @@ class IdMapping:
         """Turns the values without a mapped id into None."""
         return [None if v.id in self.mapping else v for v in values]
     
-    def apply_or_match(self, values: list[T], matcher: Callable[[list[T]], list[Optional[int]]]) -> list[T]:
+    def apply_or_match(self, values: list[T], matcher: Callable[[list[T]], Iterable[Optional[int]]]) -> list[T]:
         """Maps the values with a mapped id directly and uses the matcher function for all others."""
         known_ids = [self.get(d.id) if d.id else None for d in values]
         unmapped_values = self.filter_unmapped(values)
@@ -181,20 +181,20 @@ class Store:
     
     # Match methods
 
-    def match_tracks(self, tracks: list[TrackHeader]) -> list[Optional[int]]:
-        """Fetches a list of track ids that match."""
+    def match_tracks(self, tracks: list[TrackHeader]) -> Iterable[Optional[int]]:
+        """Fetches track ids that match the name/artist or similar."""
         return [None for _ in tracks]
 
-    def match_crates(self, crates: list[CrateHeader]) -> list[Optional[int]]:
-        """Fetches a list of crate ids that match."""
+    def match_crates(self, crates: list[CrateHeader]) -> Iterable[Optional[int]]:
+        """Fetches crate ids that match the name or similar."""
         return [None for _ in crates]
     
-    def match_playlists(self, playlists: list[PlaylistHeader]) -> list[Optional[int]]:
-        """Fetches a list of playlist ids that match."""
+    def match_playlists(self, playlists: list[PlaylistHeader]) -> Iterable[Optional[int]]:
+        """Fetches playlist ids that match the name or similar."""
         return [None for _ in playlists]
 
-    def match_directories(self, directories: list[Directory]) -> list[Optional[int]]:
-        """Fetches a list of directory ids that match."""
+    def match_directories(self, directories: list[Directory]) -> Iterable[Optional[int]]:
+        """Fetches directory ids that match the location or similar."""
         return [None for _ in directories]
 
     # Query methods

--- a/mixync/store/__init__.py
+++ b/mixync/store/__init__.py
@@ -132,10 +132,10 @@ class Store:
                         suffix = f"' ({len(raw) / 1_000_000} MB)"
                         terminal_width = get_terminal_size((80, 20)).columns
                         available_width = max(5, terminal_width - len(progress.prefix()) - len(prefix) - len(suffix) - 3)
-                        progress.print(prefix + truncate(Path(location).name, available_width) + suffix)
+                        progress.update(prefix + truncate(Path(location).name, available_width) + suffix)
                 except Exception as e:
-                    print(f'Could not copy {track.name}: {e}')
-                    progress.print(f'Skipping track...')
+                    progress.print(f'Could not copy {track.name}: {e}')
+                    progress.update(f'Skipping track...')
         if opts.log:
             info(f'Copied {copied_count} track files ({len(zipped_tracks) - copied_count} skipped)')
 

--- a/mixync/store/debug.py
+++ b/mixync/store/debug.py
@@ -1,8 +1,13 @@
+from typing import TypeVar
+
 from mixync.model.crate import Crate
 from mixync.model.directory import Directory
 from mixync.model.playlist import Playlist
 from mixync.model.track import Track
 from mixync.store import Store
+from mixync.utils.typing import HasId
+
+T = TypeVar('T', bound='HasId')
 
 class DebugStore(Store):
     """A simple store that outputs updates to stdout for debugging."""
@@ -18,25 +23,36 @@ class DebugStore(Store):
             return DebugStore(compact=True)
         return None
     
+    def _fake_ids(self, values: list[T]) -> list[int]:
+        i = max([0] + [v.id for v in values if v.id]) + 1
+        new_ids = []
+        for value in values:
+            if value.id:
+                new_ids.append(value.id)
+            else:
+                new_ids.append(i)
+                i += 1
+        return new_ids
+    
     def update_tracks(self, tracks: list[Track]) -> list[int]:
         for track in tracks:
             print(track.name if self.compact else track)
-        return list(range(len(tracks)))
+        return self._fake_ids(tracks)
 
     def update_crates(self, crates: list[Crate]) -> list[int]:
         for crate in crates:
             print(crate.name if self.compact else crate)
-        return list(range(len(crates)))
+        return self._fake_ids(crates)
 
     def update_playlists(self, playlists: list[Playlist]) -> list[int]:
         for playlist in playlists:
             print(playlist.name if self.compact else playlist)
-        return list(range(len(playlists)))
+        return self._fake_ids(playlists)
 
     def update_directories(self, directories: list[Directory]) -> list[int]:
         for directory in directories:
             print(directory.location if self.compact else directory)
-        return list(range(len(directories)))
+        return self._fake_ids(directories)
 
     # Upload/download methods
 

--- a/mixync/store/debug.py
+++ b/mixync/store/debug.py
@@ -5,9 +5,9 @@ from mixync.model.directory import Directory
 from mixync.model.playlist import Playlist
 from mixync.model.track import Track
 from mixync.store import Store
-from mixync.utils.typing import HasId
+from mixync.utils.typing import Identifiable
 
-T = TypeVar('T', bound='HasId')
+T = TypeVar('T', bound='Identifiable')
 
 class DebugStore(Store):
     """A simple store that outputs updates to stdout for debugging."""

--- a/mixync/store/debug.py
+++ b/mixync/store/debug.py
@@ -1,15 +1,8 @@
-from __future__ import annotations
-from typing import Optional, Iterable
-
 from mixync.model.crate import Crate
-from mixync.model.cue import Cue
 from mixync.model.directory import Directory
 from mixync.model.playlist import Playlist
 from mixync.model.track import Track
-from mixync.options import Options
 from mixync.store import Store
-from mixync.utils.progress import ProgressLine
-from mixync.utils.str import truncate
 
 class DebugStore(Store):
     """A simple store that outputs updates to stdout for debugging."""
@@ -25,25 +18,25 @@ class DebugStore(Store):
             return DebugStore(compact=True)
         return None
     
-    def update_tracks(self, tracks: list[Track]) -> int:
+    def update_tracks(self, tracks: list[Track]) -> list[int]:
         for track in tracks:
             print(track.name if self.compact else track)
-        return len(tracks)
+        return list(range(len(tracks)))
 
-    def update_crates(self, crates: list[Crate]) -> int:
+    def update_crates(self, crates: list[Crate]) -> list[int]:
         for crate in crates:
             print(crate.name if self.compact else crate)
-        return len(crates)
+        return list(range(len(crates)))
 
-    def update_playlists(self, playlists: list[Playlist]) -> int:
+    def update_playlists(self, playlists: list[Playlist]) -> list[int]:
         for playlist in playlists:
             print(playlist.name if self.compact else playlist)
-        return len(playlists)
+        return list(range(len(playlists)))
 
-    def update_directories(self, directories: list[Directory]) -> int:
+    def update_directories(self, directories: list[Directory]) -> list[int]:
         for directory in directories:
             print(directory.location if self.compact else directory)
-        return len(directories)
+        return list(range(len(directories)))
 
     # Upload/download methods
 

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -310,7 +310,7 @@ class MixxxStore(Store):
                 path = Path(track.location).resolve()
                 location = session.query(MixxxTrackLocation).where(MixxxTrackLocation.location == track.location).first()
                 if not location:
-                    location = session.add(MixxxTrackLocation(
+                    location = session.merge(MixxxTrackLocation(
                         location=track.location,
                         filename=path.name,
                         directory=str(path.parent),

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -1,4 +1,4 @@
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, delete
 from sqlalchemy.orm import sessionmaker
 from hashlib import sha1
 from pathlib import Path
@@ -14,6 +14,7 @@ from mixync.model.keys import Keys
 from mixync.model.playlist import Playlist
 from mixync.model.track import Track
 from mixync.store import Store
+from mixync.store.mixxx.model import directory
 from mixync.store.mixxx.model.crate import *
 from mixync.store.mixxx.model.crate_track import *
 from mixync.store.mixxx.model.cue import *
@@ -254,7 +255,18 @@ class MixxxStore(Store):
         new_ids = []
         with self.make_session.begin() as session:
             for track in tracks:
-                # TODO: Location, cues
+                location = session.query(MixxxTrackLocation).where(MixxxTrackLocation.location == track.location).first()
+                if not location:
+                    path = Path(track.location).resolve()
+                    location = session.add(MixxxTrackLocation(
+                        location=track.location,
+                        filename=path.name,
+                        directory=str(path.parent),
+                        filesize=path.stat().st_size,
+                        fs_deleted=0,
+                        needs_verification=0
+                    ))
+                # TODO: Insert main cue point as 'cuepoint' (in addition to the cues below)?
                 new_track = session.merge(MixxxTrack(
                     id=track.id,
                     name=track.name,
@@ -262,6 +274,7 @@ class MixxxStore(Store):
                     album=track.album,
                     year=track.year,
                     genre=track.genre,
+                    location=location.id,
                     comment=track.comment,
                     url=track.url,
                     duration=float(track.duration_ms) / 1000.0 if track.duration_ms else None,
@@ -281,6 +294,19 @@ class MixxxStore(Store):
                 ))
                 session.flush()
                 new_ids.append(new_track.id)
+                # TODO: More sophisticated cue merging strategy?
+                if track.cues:
+                    session.execute(delete(MixxxCue).where(MixxxCue.track_id == new_track.id))
+                    for cue in track.cues:
+                        session.merge(MixxxCue(
+                            type=cue.type,
+                            position_ms=cue.position_ms,
+                            length_ms=cue.length_ms,
+                            hotcue=cue.hotcue,
+                            label=cue.label,
+                            color=cue.color,
+                            track_id=new_track.id
+                        ))
         return new_ids
 
     def update_directories(self, directories: list[Directory]) -> list[int]:

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -1,11 +1,12 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, make_transient
+from sqlalchemy.orm import sessionmaker
+from hashlib import sha1
 from pathlib import Path
-from typing import Iterable, Optional, Type, TypeVar
+from typing import Iterable, Optional, TypeVar
 
 import sys
-from mixync.model.beats import Beats
 
+from mixync.model.beats import Beats
 from mixync.model.crate import Crate
 from mixync.model.cue import Cue
 from mixync.model.directory import Directory
@@ -158,7 +159,7 @@ class MixxxStore(Store):
         with self.make_session() as session:
             for directory in session.query(MixxxDirectory):
                 yield Directory(
-                    id=None,
+                    id=int(sha1(directory.directory.encode('utf8')).hexdigest(), 16),
                     location=directory.directory
                 )
     

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -279,6 +279,7 @@ class MixxxStore(Store):
                     rating=track.rating,
                     color=track.color
                 ))
+                session.flush()
                 new_ids.append(new_track.id)
         return new_ids
 
@@ -289,6 +290,7 @@ class MixxxStore(Store):
                 session.merge(MixxxDirectory(
                     location=directory.location
                 ))
+                session.flush()
                 new_ids.append(self._directory_id(directory.location))
         return new_ids
 
@@ -303,6 +305,7 @@ class MixxxStore(Store):
                     count=len(crate.track_ids),
                     locked=crate.locked
                 ))
+                session.flush()
                 new_ids.append(new_crate.id)
         return new_ids
 
@@ -319,6 +322,7 @@ class MixxxStore(Store):
                     type=playlist.type,
                     locked=playlist.locked
                 ))
+                session.flush()
                 new_ids.append(new_playlist.id)
         return new_ids
     

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -341,7 +341,8 @@ class MixxxStore(Store):
                     channels=track.channels,
                     timesplayed=track.times_played,
                     rating=track.rating,
-                    color=track.color
+                    color=track.color,
+                    mixxx_deleted=0
                 ))
                 session.flush()
                 new_ids.append(new_track.id)

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -162,7 +162,7 @@ class MixxxStore(Store):
             raise ValueError('Cannot absolutize a track with an empty location path.')
         matching_directory = self._find_matching_directory(location.parts[0], opts).resolve()
         matching_location = matching_directory.parent / location
-        if opts.log:
+        if opts.log and opts.verbose:
             print(f"Mapping '{track.location}' to '{matching_location}'")
         new_track.location = str(matching_location)
         return new_track

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -354,7 +354,7 @@ class MixxxStore(Store):
         with self.make_session() as session:
             for directory in directories:
                 session.merge(MixxxDirectory(
-                    location=directory.location
+                    directory=directory.location
                 ))
                 session.flush()
                 new_ids.append(self._directory_id(directory.location))

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -279,11 +279,8 @@ class MixxxStore(Store):
     def match_directories(self, directories: list[Directory]) -> Iterable[Optional[int]]:
         with self.make_session() as session:
             for directory in directories:
-                yield self._query_id(
-                    session,
-                    MixxxDirectory,
-                    MixxxDirectory.directory == directory.location
-                )
+                row = session.query(MixxxDirectory).where(MixxxDirectory.directory == directory.location).first()
+                yield self._directory_id(row.directory) if row else None
     
     def match_playlists(self, playlists: list[PlaylistHeader]) -> Iterable[Optional[int]]:
         with self.make_session() as session:

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -153,7 +153,19 @@ class MixxxStore(Store):
         new_directory.location = str(matching_location)
         return new_directory
     
-    # TODO: absolutize_track
+    def absolutize_track(self, track: Track, opts: Options) -> Optional[Track]:
+        new_track = super().absolutize_track(track, opts)
+        if not new_track:
+            return None
+        location = Path(track.location)
+        if not location.parts:
+            raise ValueError('Cannot absolutize a track with an empty location path.')
+        matching_directory = self._find_matching_directory(location.parts[0], opts).resolve()
+        matching_location = matching_directory.parent / location
+        if opts.log:
+            print(f"Mapping '{track.location}' to '{matching_location}'")
+        new_track.location = str(matching_location)
+        return new_track
     
     def _directory_id(self, location: str) -> int:
         return int(sha1(location.encode('utf8')).hexdigest(), 16)

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -270,7 +270,7 @@ class MixxxStore(Store):
                 yield self._query_id(
                     session,
                     MixxxDirectory,
-                    MixxxDirectory.location == directory.location
+                    MixxxDirectory.directory == directory.location
                 )
     
     def match_playlists(self, playlists: list[PlaylistHeader]) -> Iterable[Optional[int]]:

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -410,7 +410,7 @@ class MixxxStore(Store):
                     name=playlist.name,
                     # TODO: Merge position
                     # position=playlist.position,
-                    type=playlist.type,
+                    hidden=playlist.type,
                     locked=playlist.locked
                 ))
                 session.flush()

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -319,6 +319,7 @@ class MixxxStore(Store):
                         fs_deleted=0,
                         needs_verification=0
                     ))
+                    session.flush()
                 # TODO: Insert main cue point as 'cuepoint' (in addition to the cues below)?
                 new_track = session.merge(MixxxTrack(
                     id=track.id,

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -308,61 +308,58 @@ class MixxxStore(Store):
         with self.make_session.begin() as session:
             for track in tracks:
                 path = Path(track.location).resolve()
-                if path.exists():
-                    location = session.query(MixxxTrackLocation).where(MixxxTrackLocation.location == track.location).first()
-                    if not location:
-                        location = session.add(MixxxTrackLocation(
-                            location=track.location,
-                            filename=path.name,
-                            directory=str(path.parent),
-                            filesize=path.stat().st_size,
-                            fs_deleted=0,
-                            needs_verification=0
-                        ))
-                    # TODO: Insert main cue point as 'cuepoint' (in addition to the cues below)?
-                    new_track = session.merge(MixxxTrack(
-                        id=track.id,
-                        title=track.name,
-                        artist=track.artist,
-                        album=track.album,
-                        year=track.year,
-                        genre=track.genre,
-                        location=location.id,
-                        comment=track.comment,
-                        url=track.url,
-                        duration=float(track.duration_ms) / 1000.0 if track.duration_ms else None,
-                        samplerate=track.sample_rate,
-                        bpm=track.bpm,
-                        beats=track.beats.data if track.beats else None,
-                        beats_version=track.beats.version if track.beats else None,
-                        beats_sub_version=track.beats.sub_version if track.beats else None,
-                        key=track.key,
-                        keys=track.keys.data if track.keys else None,
-                        keys_version=track.keys.version if track.keys else None,
-                        keys_sub_version=track.keys.sub_version if track.keys else None,
-                        channels=track.channels,
-                        timesplayed=track.times_played,
-                        rating=track.rating,
-                        color=track.color
+                location = session.query(MixxxTrackLocation).where(MixxxTrackLocation.location == track.location).first()
+                if not location:
+                    location = session.add(MixxxTrackLocation(
+                        location=track.location,
+                        filename=path.name,
+                        directory=str(path.parent),
+                        # TODO: Determine filesize?
+                        filesize=None,
+                        fs_deleted=0,
+                        needs_verification=0
                     ))
-                    session.flush()
-                    new_ids.append(new_track.id)
-                    # TODO: More sophisticated cue merging strategy?
-                    if track.cues:
-                        session.execute(delete(MixxxCue).where(MixxxCue.track_id == new_track.id))
-                        for cue in track.cues:
-                            session.merge(MixxxCue(
-                                type=cue.type,
-                                position_ms=cue.position_ms,
-                                length_ms=cue.length_ms,
-                                hotcue=cue.hotcue,
-                                label=cue.label,
-                                color=cue.color,
-                                track_id=new_track.id
-                            ))
-                else:
-                    print(f"Warning: Track '{track.name}' does not exist at {track.location}, skipping")
-                    new_ids.append(None)
+                # TODO: Insert main cue point as 'cuepoint' (in addition to the cues below)?
+                new_track = session.merge(MixxxTrack(
+                    id=track.id,
+                    title=track.name,
+                    artist=track.artist,
+                    album=track.album,
+                    year=track.year,
+                    genre=track.genre,
+                    location=location.id,
+                    comment=track.comment,
+                    url=track.url,
+                    duration=float(track.duration_ms) / 1000.0 if track.duration_ms else None,
+                    samplerate=track.sample_rate,
+                    bpm=track.bpm,
+                    beats=track.beats.data if track.beats else None,
+                    beats_version=track.beats.version if track.beats else None,
+                    beats_sub_version=track.beats.sub_version if track.beats else None,
+                    key=track.key,
+                    keys=track.keys.data if track.keys else None,
+                    keys_version=track.keys.version if track.keys else None,
+                    keys_sub_version=track.keys.sub_version if track.keys else None,
+                    channels=track.channels,
+                    timesplayed=track.times_played,
+                    rating=track.rating,
+                    color=track.color
+                ))
+                session.flush()
+                new_ids.append(new_track.id)
+                # TODO: More sophisticated cue merging strategy?
+                if track.cues:
+                    session.execute(delete(MixxxCue).where(MixxxCue.track_id == new_track.id))
+                    for cue in track.cues:
+                        session.merge(MixxxCue(
+                            type=cue.type,
+                            position_ms=cue.position_ms,
+                            length_ms=cue.length_ms,
+                            hotcue=cue.hotcue,
+                            label=cue.label,
+                            color=cue.color,
+                            track_id=new_track.id
+                        ))
         return new_ids
 
     def update_directories(self, directories: list[Directory]) -> list[int]:

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -368,7 +368,7 @@ class MixxxStore(Store):
 
     def update_directories(self, directories: list[Directory]) -> list[int]:
         new_ids = []
-        with self.make_session() as session:
+        with self.make_session.begin() as session:
             for directory in directories:
                 session.merge(MixxxDirectory(
                     directory=directory.location
@@ -379,7 +379,7 @@ class MixxxStore(Store):
 
     def update_crates(self, crates: list[Crate]) -> list[int]:
         new_ids = []
-        with self.make_session() as session:
+        with self.make_session.begin() as session:
             for crate in crates:
                 new_crate = session.merge(MixxxCrate(
                     id=crate.id,
@@ -400,7 +400,7 @@ class MixxxStore(Store):
 
     def update_playlists(self, playlists: list[Playlist]) -> list[int]:
         new_ids = []
-        with self.make_session() as session:
+        with self.make_session.begin() as session:
             for playlist in playlists:
                 new_playlist = session.merge(MixxxPlaylist(
                     id=playlist.id,

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -158,6 +158,7 @@ class MixxxStore(Store):
         with self.make_session() as session:
             for directory in session.query(MixxxDirectory):
                 yield Directory(
+                    id=None,
                     location=directory.directory
                 )
     

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -247,8 +247,22 @@ class MixxxStore(Store):
                     track_ids=[t.id for t in session.query(MixxxPlaylistTrack).where(MixxxPlaylistTrack.playlist_id == playlist.id)]
                 )
     
-    # TODO: Update methods and upload
+    def update_tracks(self, tracks: list[Track]) -> list[int]:
+        # TODO
+        return super().update_tracks(tracks)
 
+    def update_directories(self, directories: list[Directory]) -> list[int]:
+        # TODO
+        return super().update_directories(directories)
+
+    def update_crates(self, crates: list[Crate]) -> list[int]:
+        # TODO
+        return super().update_crates(crates)
+
+    def update_playlists(self, playlists: list[Playlist]) -> list[int]:
+        # TODO
+        return super().update_playlists(playlists)
+    
     def download_track(self, location: str) -> bytes:
         with open(location, 'rb') as f:
             return f.read()

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -430,5 +430,6 @@ class MixxxStore(Store):
             return f.read()
         
     def upload_track(self, location: str, raw: bytes):
+        Path(location).parent.mkdir(parents=True, exist_ok=True)
         with open(location, 'wb') as f:
             f.write(raw)

--- a/mixync/store/mixxx/__init__.py
+++ b/mixync/store/mixxx/__init__.py
@@ -309,7 +309,7 @@ class MixxxStore(Store):
                 # TODO: Insert main cue point as 'cuepoint' (in addition to the cues below)?
                 new_track = session.merge(MixxxTrack(
                     id=track.id,
-                    name=track.name,
+                    title=track.name,
                     artist=track.artist,
                     album=track.album,
                     year=track.year,

--- a/mixync/store/portable/__init__.py
+++ b/mixync/store/portable/__init__.py
@@ -54,7 +54,7 @@ class PortableStore(Store):
             for track in session.query(PortableTrack).where(*constraints):
                 yield Track(
                     id=track.id,
-                    name=track.title,
+                    name=track.name,
                     artist=track.artist,
                     location=track.location,
                     album=track.album,

--- a/mixync/store/portable/__init__.py
+++ b/mixync/store/portable/__init__.py
@@ -233,8 +233,8 @@ class PortableStore(Store):
                 ))
                 session.flush()
                 new_ids.append(new_crate.id)
+                # TODO: More sophisticated crate merging strategy (should we delete old tracks like with playlists?)
                 for track_id in crate.track_ids:
-                    # TODO: Delete old tracks?
                     session.merge(PortableCrateTrack(
                         crate_id=new_crate.id,
                         track_id=track_id
@@ -256,6 +256,7 @@ class PortableStore(Store):
                 ))
                 session.flush()
                 new_ids.append(new_playlist.id)
+                # TODO: More sophisticated playlist merging strategy than just replacing?
                 session.execute(delete(PortablePlaylistTrack).where(PortablePlaylistTrack.playlist_id == new_playlist.id))
                 for i, track_id in enumerate(playlist.track_ids):
                     session.merge(PortablePlaylistTrack(

--- a/mixync/store/portable/__init__.py
+++ b/mixync/store/portable/__init__.py
@@ -233,7 +233,8 @@ class PortableStore(Store):
                 ))
                 session.flush()
                 new_ids.append(new_crate.id)
-                # TODO: More sophisticated crate merging strategy (should we delete old tracks like with playlists?)
+                # TODO: More sophisticated crate merging strategy
+                # (should we delete old tracks like with playlists, even though we don't have to worry about order?)
                 for track_id in crate.track_ids:
                     session.merge(PortableCrateTrack(
                         crate_id=new_crate.id,

--- a/mixync/store/portable/__init__.py
+++ b/mixync/store/portable/__init__.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine, delete
-from sqlalchemy.orm import sessionmaker, make_transient
+from sqlalchemy.orm import sessionmaker
 from pathlib import Path
 from typing import Iterable
 
@@ -196,16 +196,16 @@ class PortableStore(Store):
                 # TODO: More sophisticated cue merging strategy?
                 if track.cues:
                     session.execute(delete(PortableCue).where(PortableCue.track_id == new_track.id))
-                for cue in track.cues:
-                    session.merge(PortableCue(
-                        type=cue.type,
-                        position_ms=cue.position_ms,
-                        length_ms=cue.length_ms,
-                        hotcue=cue.hotcue,
-                        label=cue.label,
-                        color=cue.color,
-                        track_id=new_track.id
-                    ))
+                    for cue in track.cues:
+                        session.merge(PortableCue(
+                            type=cue.type,
+                            position_ms=cue.position_ms,
+                            length_ms=cue.length_ms,
+                            hotcue=cue.hotcue,
+                            label=cue.label,
+                            color=cue.color,
+                            track_id=new_track.id
+                        ))
         return new_ids
 
     def update_directories(self, directories: list[Directory]) -> list[int]:

--- a/mixync/store/portable/__init__.py
+++ b/mixync/store/portable/__init__.py
@@ -121,6 +121,7 @@ class PortableStore(Store):
         with self.make_session() as session:
             for directory in session.query(PortableDirectory):
                 yield Directory(
+                    id=directory.id,
                     location=directory.location
                 )
     

--- a/mixync/store/portable/__init__.py
+++ b/mixync/store/portable/__init__.py
@@ -123,6 +123,43 @@ class PortableStore(Store):
     def _query_id(self, session, cls, *constraints) -> Optional[int]:
         row = session.query(cls).where(*constraints).first()
         return row.id if row else None
+    
+    def match_tracks(self, tracks: list[TrackHeader]) -> Iterable[Optional[int]]:
+        with self.make_session() as session:
+            for track in tracks:
+                yield self._query_id(
+                    session,
+                    PortableTrack,
+                    PortableTrack.name == track.name,
+                    PortableTrack.artist == track.artist
+                )
+    
+    def match_directories(self, directories: list[Directory]) -> Iterable[Optional[int]]:
+        with self.make_session() as session:
+            for directory in directories:
+                yield self._query_id(
+                    session,
+                    PortableDirectory,
+                    PortableDirectory.location == directory.location
+                )
+    
+    def match_playlists(self, playlists: list[PlaylistHeader]) -> Iterable[Optional[int]]:
+        with self.make_session() as session:
+            for playlist in playlists:
+                yield self._query_id(
+                    session,
+                    PortablePlaylist,
+                    PortablePlaylist.name == playlist.name
+                )
+    
+    def match_crates(self, crates: list[CrateHeader]) -> Iterable[Optional[int]]:
+        with self.make_session() as session:
+            for crate in crates:
+                yield self._query_id(
+                    session,
+                    PortableCrate,
+                    PortableCrate.name == crate.name
+                )
 
     def update_tracks(self, tracks: list[Track]) -> list[int]:
         new_ids = []

--- a/mixync/utils/list.py
+++ b/mixync/utils/list.py
@@ -1,6 +1,7 @@
-from typing import Optional, TypeVar, Any
+from typing import Callable, Optional, TypeVar, Any
 
 T = TypeVar('T')
+U = TypeVar('U')
 
 def zip_or(xs: list[Optional[T]], ys: list[Optional[T]]) -> list[Optional[T]]:
     return [x or y for x, y in zip(xs, ys)]
@@ -14,3 +15,6 @@ def uncompact(xs: list[T], pattern: list[Optional[Any]]) -> list[Optional[T]]:
     for p in pattern:
         ys.append(next(it) if p else None)
     return ys
+
+def with_compact(f: Callable[[list[T]], list[U]], xs: list[Optional[T]]) -> list[Optional[U]]:
+    return uncompact(f(compact(xs)), xs)

--- a/mixync/utils/list.py
+++ b/mixync/utils/list.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, TypeVar, Any
+from typing import Callable, Iterable, Optional, TypeVar, Any
 
 T = TypeVar('T')
 U = TypeVar('U')
@@ -16,5 +16,5 @@ def uncompact(xs: list[T], pattern: list[Optional[Any]]) -> list[Optional[T]]:
         ys.append(next(it) if p else None)
     return ys
 
-def with_compact(f: Callable[[list[T]], list[U]], xs: list[Optional[T]]) -> list[Optional[U]]:
-    return uncompact(f(compact(xs)), xs)
+def with_compact(f: Callable[[list[T]], Iterable[U]], xs: list[Optional[T]]) -> list[Optional[U]]:
+    return uncompact(list(f(compact(xs))), xs)

--- a/mixync/utils/list.py
+++ b/mixync/utils/list.py
@@ -1,0 +1,6 @@
+from typing import Optional, TypeVar
+
+T = TypeVar('T')
+
+def zip_or(xs: list[Optional[T]], ys: list[Optional[T]]) -> list[Optional[T]]:
+    return [x or y for x, y in zip(xs, ys)]

--- a/mixync/utils/list.py
+++ b/mixync/utils/list.py
@@ -1,6 +1,16 @@
-from typing import Optional, TypeVar
+from typing import Optional, TypeVar, Any
 
 T = TypeVar('T')
 
 def zip_or(xs: list[Optional[T]], ys: list[Optional[T]]) -> list[Optional[T]]:
     return [x or y for x, y in zip(xs, ys)]
+
+def compact(xs: list[Optional[T]]) -> list[T]:
+    return [x for x in xs if x]
+
+def uncompact(xs: list[T], pattern: list[Optional[Any]]) -> list[Optional[T]]:
+    it = iter(xs)
+    ys = []
+    for p in pattern:
+        ys.append(next(it) if p else None)
+    return ys

--- a/mixync/utils/progress.py
+++ b/mixync/utils/progress.py
@@ -8,6 +8,7 @@ class ProgressLine:
         self.i = 0
         self.total = total
         self.last_msg = ''
+        self.msg = ''
         self.with_bar = with_bar
         self.bar_length = bar_length
         self.final_newline = final_newline
@@ -25,12 +26,18 @@ class ProgressLine:
         bar = f"[{'█' * steps + '░' * (self.bar_length - steps)}]" if self.with_bar else ''
         return f'{bar} [{self.i + 1}/{self.total}]'
 
-    def print(self, msg: str):
-        output = ' '.join(s for s in [
+    def current(self):
+        return ' '.join(s for s in [
             self.prefix(),
-            msg,
-            ' ' * (len(self.last_msg) - len(msg)),
+            self.msg,
+            ' ' * (len(self.last_msg) - len(self.msg)),
         ] if s)
-        print(f'\r{output}', end='', flush=True)
-        self.last_msg = msg
+
+    def update(self, msg: str):
+        self.last_msg = self.msg
+        self.msg = msg
         self.i += 1
+        print(f'\r{self.current()}', end='', flush=True)
+    
+    def print(self, msg: str):
+        print(f"\r{' ' * len(self.last_msg)}{msg}\n{self.current()}", end='', flush=True)

--- a/mixync/utils/progress.py
+++ b/mixync/utils/progress.py
@@ -40,4 +40,5 @@ class ProgressLine:
         print(f'\r{self.current()}', end='', flush=True)
     
     def print(self, msg: str):
-        print(f"\r{' ' * len(self.last_msg)}{msg}\n{self.current()}", end='', flush=True)
+        print(f"\r{msg}{' ' * (len(self.last_msg) - len(msg))}\n{self.current()}", end='', flush=True)
+        self.last_msg = msg

--- a/mixync/utils/typing.py
+++ b/mixync/utils/typing.py
@@ -1,4 +1,4 @@
 from typing import Protocol, Optional
 
-class HasId(Protocol):
+class Identifiable(Protocol):
     id: Optional[int]

--- a/mixync/utils/typing.py
+++ b/mixync/utils/typing.py
@@ -1,0 +1,4 @@
+from typing import Protocol, Optional
+
+class HasId(Protocol):
+    id: Optional[int]


### PR DESCRIPTION
### Implements #12

Letting the `Store` (base class) take care of the id mapping makes the actual implementations easier since they can always assume to deal in their own indexing scheme, with the only requirement of providing a 'matching' method for foreign tracks/crates/playlists.

- [x] Factor the `copy_to` method
- [x] Add some utilities
- [x] Implement the actual id mapping in the store
- [x] Update the stores themselves (especially the portable and the mixxxdb one) to
  - [x] ...provide matching methods
  - [x] ...deal in terms of their indices
- [ ] Testing, testing, testing!
  - [x] Investigate why directories don't seem to be inserted into the mixxxdb (session weren't initialized correctly)
  - [ ] Investigate why inserted tracks don't show up in the Mixxx UI